### PR TITLE
Clean up docs in various modules

### DIFF
--- a/src/Options/Applicative/BashCompletion.purs
+++ b/src/Options/Applicative/BashCompletion.purs
@@ -1,8 +1,7 @@
 -- | You don't need to import this module to enable bash completion.
---
--- See
--- <http://github.com/pcapriotti/optparse-applicative/wiki/Bash-Completion the wiki>
--- for more information on bash completion.
+-- |
+-- | See [the wiki](http://github.com/pcapriotti/optparse-applicative/wiki/Bash-Completion)
+-- | for more information on bash completion.
 module Options.Applicative.BashCompletion
   ( bashCompletionParser
   ) where
@@ -85,7 +84,7 @@ bashCompletionQuery pinfo pprefs richness ws i _ = case runCompletion compl ppre
   Just (Left (Tuple (SomeParser e) a))
     -> runExists (\p -> list_options a p) e
   Just (Right c)
-    -> run_completer c 
+    -> run_completer c
   Nothing
     -> pure []
   where
@@ -207,24 +206,23 @@ bashCompletionScript prog progn = pure
   , ""
   , "complete -o filenames -F _" <> progn <> " " <> progn ]
 
-{-
-/Note/: Fish Shell
-
-Derived from Drezil's post in #169.
-
-@
-commandline
--c or --cut-at-cursor only print selection up until the current cursor position
--o or --tokenize tokenize the selection and print one string-type token per line
-@
-
-We tokenize so that the call to count (and hence --bash-completion-index)
-gets the right number use cut-at-curstor to not bother sending anything
-after the cursor position, which allows for completion of the middle of
-words.
-
-Tab characters separate items from descriptions.
--}
+-- |
+-- | **Note**: Fish Shell
+-- |
+-- | Derived from Drezil's post in #169.
+-- |
+-- | ```
+-- | commandline
+-- | -c or --cut-at-cursor only print selection up until the current cursor position
+-- | -o or --tokenize tokenize the selection and print one string-type token per line
+-- | ```
+-- |
+-- | We tokenize so that the call to count (and hence --bash-completion-index)
+-- | gets the right number use cut-at-curstor to not bother sending anything
+-- | after the cursor position, which allows for completion of the middle of
+-- | words.
+-- |
+-- | Tab characters separate items from descriptions.
 fishCompletionScript :: String -> String -> Effect (Array String)
 fishCompletionScript prog progn = pure
   [ " function _" <> progn

--- a/src/Options/Applicative/Builder.purs
+++ b/src/Options/Applicative/Builder.purs
@@ -287,7 +287,7 @@ strArgument :: Mod ArgumentFields String -> Parser String
 strArgument = argument str
 
 -- | Builder for a flag parser.
---
+-- |
 -- | A flag that switches from a \"default value\" to an \"active value\" when
 -- | encountered. For a simple boolean value, use `switch` instead.
 -- |

--- a/src/Options/Applicative/Builder.purs
+++ b/src/Options/Applicative/Builder.purs
@@ -1,21 +1,23 @@
-module Options.Applicative.Builder
   -- * Parser builders
   --
   -- | This module contains utility functions and combinators to create parsers
-  -- for individual options.
-  --
-  -- Each parser builder takes an option modifier. A modifier can be created by
-  -- composing the basic modifiers provided by this module using the 'Monoid'
-  -- operations 'mempty' and 'append', or their aliases 'idm' and '<>'.
-  --
-  -- For example:
-  --
-  -- > out = strOption
-  -- >     ( long "output"
-  -- >    <> short 'o'
-  -- >    <> metavar "FILENAME" )
-  --
-  -- creates a parser for an option called \"output\".
+  -- | for individual options.
+  -- |
+  -- | Each parser builder takes an option modifier. A modifier can be created by
+  -- | composing the basic modifiers provided by this module using the 'Monoid'
+  -- | operations 'mempty' and 'append', or their aliases 'idm' and '<>'.
+  -- |
+  -- | For example:
+  -- |
+  -- | ```purescript
+  -- | out = strOption
+  -- |     ( long "output"
+  -- |    <> short 'o'
+  -- |    <> metavar "FILENAME" )
+  -- | ```
+  -- |
+  -- | creates a parser for an option called `output`.
+module Options.Applicative.Builder
   ( subparser
   , strArgument
   , argument
@@ -137,14 +139,6 @@ boolean = eitherReader $ toLower >>> case _ of
   s -> Left $ "Can't parse as Boolean: `" <> show s <> "`"
 
 -- | Convert a function producing an 'Either' into a reader.
---
--- As an example, one can create a ReadM from an attoparsec Parser
--- easily with
---
--- > import qualified Data.Attoparsec.Text as A
--- > import qualified Data.Text as T
--- > attoparsecReader :: A.Parser a -> ReadM a
--- > attoparsecReader p = eitherReader (A.parseOnly p <<< T.pack)
 eitherReader :: forall a. (String -> Either String a) -> ReadM a
 eitherReader f = readerAsk >>= either readerError pure <<< f
 
@@ -169,18 +163,18 @@ long :: forall f a. HasName f => String -> Mod f a
 long = fieldMod <<< name <<< OptLong
 
 -- | Specify a default value for an option.
---
--- /Note/: Because this modifier means the parser will never fail,
--- do not use it with combinators such as 'some' or 'many', as
--- these combinators continue until a failure occurs.
--- Careless use will thus result in a hang.
---
--- To display the default value, combine with showDefault or
--- showDefaultWith.
+-- |
+-- | **Note**: Because this modifier means the parser will never fail,
+-- | do not use it with combinators such as 'some' or 'many', as
+-- | these combinators continue until a failure occurs.
+-- | Careless use will thus result in a hang.
+-- |
+-- | To display the default value, combine with `showDefault` or
+-- | `showDefaultWith`.
 value :: forall f a. HasValue f => a -> Mod f a
 value x = Mod identity (DefaultProp (Just x) Nothing) identity
 
--- | Specify a function to show the default value for an option.
+-- | Show the default value for this option using a function.
 showDefaultWith :: forall f a. (a -> String) -> Mod f a
 showDefaultWith s = Mod identity (DefaultProp Nothing (Just s)) identity
 
@@ -193,7 +187,7 @@ help :: forall a f. String -> Mod f a
 help s = optionMod $ over OptProperties \p -> p { propHelp = paragraph s }
 
 -- | Specify the help text for an option as a 'Text.PrettyPrint.ANSI.Leijen.Doc'
--- value.
+-- | value.
 helpDoc :: forall f a. Maybe Doc -> Mod f a
 helpDoc doc = optionMod $ over OptProperties \p -> p { propHelp = Chunk doc }
 
@@ -202,9 +196,9 @@ noArgError :: forall a. ParseError -> Mod OptionFields a
 noArgError e = fieldMod $ over OptionFields \p -> p { optNoArgError = const e }
 
 -- | Specify a metavariable for the argument.
---
--- Metavariables have no effect on the actual parser, and only serve to specify
--- the symbolic name for an argument to be displayed in the help text.
+-- |
+-- | Metavariables have no effect on the actual parser, and only serve to specify
+-- | the symbolic name for an argument to be displayed in the help text.
 metavar :: forall f a. HasMetavar f => String -> Mod f a
 metavar var = optionMod $ over OptProperties \p -> p { propMetaVar = var }
 
@@ -214,40 +208,40 @@ hidden = optionMod $ over OptProperties \p ->
   p { propVisibility = min Hidden p.propVisibility }
 
 -- | Apply a function to the option description in the usage text.
---
--- > import Options.Applicative.Help
--- > flag' () (short 't' <> style bold)
---
--- /NOTE/: This builder is more flexible than its name and example
--- allude. One of the motivating examples for its addition was to
--- used `const` to completely replace the usage text of an option.
+-- |
+-- | > import Options.Applicative.Help
+-- | > flag' () (short 't' <> style bold)
+-- |
+-- | **NOTE**: This builder is more flexible than its name and example
+-- | allude. One of the motivating examples for its addition was to
+-- | used `const` to completely replace the usage text of an option.
 style :: forall f a. ( Doc -> Doc ) -> Mod f a
 style x = optionMod $ over OptProperties \p ->
   p { propDescMod = Just x }
 
 -- | Add a command to a subparser option.
---
--- Suggested usage for multiple commands is to add them to a single subparser. e.g.
---
--- @
--- sample :: Parser Sample
--- sample = subparser
---        ( command "hello"
---          (info hello (progDesc "Print greeting"))
---       <> command "goodbye"
---          (info goodbye (progDesc "Say goodbye"))
---        )
--- @
+-- |
+-- | Suggested usage for multiple commands is to add them to a single subparser. e.g.
+-- |
+-- | ```purescript
+-- | sample :: Parser Sample
+-- | sample = subparser
+-- |        ( command "hello"
+-- |          (info hello (progDesc "Print greeting"))
+-- |       <> command "goodbye"
+-- |          (info goodbye (progDesc "Say goodbye"))
+-- |        )
+-- | ```
 command :: forall a. String -> ParserInfo a -> Mod CommandFields a
 command cmd pinfo = fieldMod $ over CommandFields \p ->
   p { cmdCommands = [Tuple cmd pinfo] <> p.cmdCommands }
 
 -- | Add a description to a group of commands.
---
--- Advanced feature for separating logical groups of commands on the parse line.
---
--- If using the same `metavar` for each group of commands, it may yield a more
--- attractive usage text combined with `hidden` for some groups.
+-- |
+-- | Advanced feature for separating logical groups of commands on the parse line.
+-- |
+-- | If using the same `metavar` for each group of commands, it may yield a more
+-- | attractive usage text combined with `hidden` for some groups.
 commandGroup :: forall a. String -> Mod CommandFields a
 commandGroup g = fieldMod $ over CommandFields \p ->
   p { cmdGroup = Just g }
@@ -256,24 +250,24 @@ commandGroup g = fieldMod $ over CommandFields \p ->
 completeWith :: forall f a. HasCompleter f => Array String -> Mod f a
 completeWith = completer <<< listCompleter
 
--- | Add a bash completion action. Common actions include @file@ and
--- @directory@. See
--- <http://www.gnu.org/software/bash/manual/html_node/Programmable-Completion-Builtins.html#Programmable-Completion-Builtins>
--- for a complete list.
+-- | Add a bash completion action. Common actions include `file` and
+-- | `directory`. See
+-- | <http://www.gnu.org/software/bash/manual/html_node/Programmable-Completion-Builtins.html#Programmable-Completion-Builtins>
+-- | for a complete list.
 action :: forall f a. HasCompleter f => String -> Mod f a
 action = completer <<< bashCompleter
 
 -- | Add a completer to an argument.
---
--- A completer is a function String -> IO String which, given a partial
--- argument, returns all possible completions for that argument.
+-- |
+-- | A completer is a function `String -> Effect String` which, given a partial
+-- | argument, returns all possible completions for that argument.
 completer :: forall f a. HasCompleter f => Completer -> Mod f a
 completer f = fieldMod $ modCompleter (_ `append` f)
 
 -- parsers --
 
 -- | Builder for a command parser. The 'command' modifier can be used to
--- specify individual commands.
+-- | specify individual commands.
 subparser :: forall a. Mod CommandFields a -> Parser a
 subparser m = mkParser d g rdr
   where
@@ -294,12 +288,12 @@ strArgument = argument str
 
 -- | Builder for a flag parser.
 --
--- A flag that switches from a \"default value\" to an \"active value\" when
--- encountered. For a simple boolean value, use `switch` instead.
---
--- /Note/: Because this parser will never fail, it can not be used with
--- combinators such as 'some' or 'many', as these combinators continue until
--- a failure occurs. See @flag'@.
+-- | A flag that switches from a \"default value\" to an \"active value\" when
+-- | encountered. For a simple boolean value, use `switch` instead.
+-- |
+-- | **Note**: Because this parser will never fail, it can not be used with
+-- | combinators such as 'some' or 'many', as these combinators continue until
+-- | a failure occurs. See @flag'@.
 flag :: forall a
       . a                         -- ^ default value
      -> a                         -- ^ active value
@@ -308,20 +302,20 @@ flag :: forall a
 flag defv actv m = flag' actv m <|> pure defv
 
 -- | Builder for a flag parser without a default value.
---
--- Same as 'flag', but with no default value. In particular, this flag will
--- never parse successfully by itself.
---
--- It still makes sense to use it as part of a composite parser. For example
---
--- > length <$> many (flag' () (short 't'))
---
--- is a parser that counts the number of "-t" arguments on the command line,
--- alternatively
---
--- > flag' true (long "on") <|> flag' false (long "off")
---
--- will require the user to enter '--on' or '--off' on the command line.
+-- |
+-- | Same as 'flag', but with no default value. In particular, this flag will
+-- | never parse successfully by itself.
+-- |
+-- | It still makes sense to use it as part of a composite parser. For example
+-- |
+-- | > length <$> many (flag' () (short 't'))
+-- |
+-- | is a parser that counts the number of "-t" arguments on the command line,
+-- | alternatively
+-- |
+-- | > flag' true (long "on") <|> flag' false (long "off")
+-- |
+-- | will require the user to enter '--on' or '--off' on the command line.
 flag' :: forall a
        . a                         -- ^ active value
       -> Mod FlagFields a          -- ^ option modifier
@@ -333,20 +327,20 @@ flag' actv (Mod f d g) = mkParser d g rdr
                         (fields.flagActive)
 
 -- | Builder for a boolean flag.
---
--- /Note/: Because this parser will never fail, it can not be used with
--- combinators such as 'some' or 'many', as these combinators continue until
--- a failure occurs. See @flag'@.
---
--- > switch = flag false true
+-- |
+-- | **Note**: Because this parser will never fail, it can not be used with
+-- | combinators such as 'some' or 'many', as these combinators continue until
+-- | a failure occurs. See @flag'@.
+-- |
+-- | > switch = flag false true
 switch :: Mod FlagFields Boolean -> Parser Boolean
 switch = flag false true
 
 -- | An option that always fails.
---
--- When this option is encountered, the option parser immediately aborts with
--- the given parse error.  If you simply want to output a message, use
--- 'infoOption' instead.
+-- |
+-- | When this option is encountered, the option parser immediately aborts with
+-- | the given parse error.  If you simply want to output a message, use
+-- | 'infoOption' instead.
 abortOption :: forall a. ParseError -> Mod OptionFields (a -> a) -> Parser (a -> a)
 abortOption err m = option (readerAbort err) <<< (_ `append` m) $ fold
   [ noArgError err
@@ -363,12 +357,11 @@ strOption = option str
 
 
 -- | Builder for an option using the given reader.
---
--- This is a regular option, and should always have either a @long@ or
--- @short@ name specified in the modifiers (or both).
---
--- > nameParser = option str ( long "name" <> short 'n' )
---
+-- |
+-- | This is a regular option, and should always have either a `long` or
+-- | `short` name specified in the modifiers (or both).
+-- |
+-- | > nameParser = option str ( long "name" <> short 'n' )
 option :: forall a. ReadM a -> Mod OptionFields a -> Parser a
 option r m = mkParser d g rdr
   where
@@ -387,11 +380,15 @@ instance infoModMonoid :: Monoid (InfoMod a) where
 instance infoModSemigroup :: Semigroup (InfoMod a) where
   append m1 m2 = InfoMod $ un InfoMod m2 <<< un InfoMod m1
 
--- | Show a full description in the help text of this parser.
+-- | Show a full description in the help text of this parser (i.e.
+-- | options with the `hidden` modifier will still be displayed,
+-- | unlike `briefDesc`).
 fullDesc :: forall a. InfoMod a
 fullDesc = InfoMod $ over ParserInfo \i -> i { infoFullDesc = true }
 
--- | Only show a brief description in the help text of this parser.
+-- | Only show a brief description in the help text of this parser (i.e.
+-- | options with the `hidden` modifier will NOT be displayed,
+-- | unlike `fullDesc`).
 briefDesc :: forall a. InfoMod a
 briefDesc = InfoMod $ over ParserInfo \i -> i { infoFullDesc = false }
 
@@ -400,7 +397,7 @@ header :: forall a. String -> InfoMod a
 header s = InfoMod $ over ParserInfo \i -> i { infoHeader = paragraph s }
 
 -- | Specify a header for this parser as a 'Text.PrettyPrint.ANSI.Leijen.Doc'
--- value.
+-- | value.
 headerDoc :: forall a. Maybe Doc -> InfoMod a
 headerDoc doc = InfoMod $ over ParserInfo \i -> i { infoHeader = Chunk doc }
 
@@ -409,7 +406,7 @@ footer :: forall a. String -> InfoMod a
 footer s = InfoMod $ over ParserInfo \i -> i { infoFooter = paragraph s }
 
 -- | Specify a footer for this parser as a 'Text.PrettyPrint.ANSI.Leijen.Doc'
--- value.
+-- | value.
 footerDoc :: forall a. Maybe Doc -> InfoMod a
 footerDoc doc = InfoMod $ over ParserInfo \i -> i { infoFooter = Chunk doc }
 
@@ -418,7 +415,7 @@ progDesc :: forall a. String -> InfoMod a
 progDesc s = InfoMod $ over ParserInfo \i -> i { infoProgDesc = paragraph s }
 
 -- | Specify a short program description as a 'Text.PrettyPrint.ANSI.Leijen.Doc'
--- value.
+-- | value.
 progDescDoc :: forall a. Maybe Doc -> InfoMod a
 progDescDoc doc = InfoMod $ over ParserInfo \i -> i { infoProgDesc = Chunk doc }
 
@@ -427,19 +424,19 @@ failureCode :: forall a. ExitCode -> InfoMod a
 failureCode n = InfoMod $ over ParserInfo \i -> i { infoFailureCode = n }
 
 -- | Disable parsing of regular options after arguments. After a positional
---   argument is parsed, all remaining options and arguments will be treated
---   as a positional arguments. Not recommended in general as users often
---   expect to be able to freely intersperse regular options and flags within
---   command line options.
+-- | argument is parsed, all remaining options and arguments will be treated
+-- | as a positional arguments. Not recommended in general as users often
+-- | expect to be able to freely intersperse regular options and flags within
+-- | command line options.
 noIntersperse :: forall a. InfoMod a
 noIntersperse = InfoMod $ over ParserInfo \p -> p { infoPolicy = NoIntersperse }
 
 -- | Intersperse matched options and arguments normally, but allow unmatched
---   options to be treated as positional arguments.
---   This is sometimes useful if one is wrapping a third party cli tool and
---   needs to pass options through, while also providing a handful of their
---   own options. Not recommended in general as typos by the user may not
---   yield a parse error and cause confusion.
+-- | options to be treated as positional arguments.
+-- | This is sometimes useful if one is wrapping a third party cli tool and
+-- | needs to pass options through, while also providing a handful of their
+-- | own options. Not recommended in general as typos by the user may not
+-- | yield a parse error and cause confusion.
 forwardOptions :: forall a. InfoMod a
 forwardOptions = InfoMod $ over ParserInfo \p -> p { infoPolicy = ForwardOptions }
 
@@ -466,14 +463,14 @@ instance prefsModSemigroup :: Semigroup PrefsMod where
   append m1 m2 = PrefsMod $ un PrefsMod m2 <<< un PrefsMod m1
 
 -- | Include a suffix to attach to the metavar when multiple values
---   can be entered.
+-- | can be entered.
 multiSuffix :: String -> PrefsMod
 multiSuffix s = PrefsMod $ over ParserPrefs \p -> p { prefMultiSuffix = s }
 
 -- | Turn on disambiguation.
---
---   See
---   https://github.com/pcapriotti/optparse-applicative#disambiguation
+-- |
+-- | See
+-- | https://github.com/pcapriotti/optparse-applicative#disambiguation
 disambiguate :: PrefsMod
 disambiguate = PrefsMod $ over ParserPrefs \p -> p { prefDisambiguate = true }
 
@@ -482,10 +479,10 @@ showHelpOnError :: PrefsMod
 showHelpOnError = PrefsMod $ over ParserPrefs \p -> p { prefShowHelpOnError = true }
 
 -- | Show the help text if the user enters only the program name or
---   subcommand.
---
---   This will suppress a "Missing:" error and show the full usage
---   instead if a user just types the name of the program.
+-- | subcommand.
+-- |
+-- | This will suppress a "Missing:" error and show the full usage
+-- | instead if a user just types the name of the program.
 showHelpOnEmpty :: PrefsMod
 showHelpOnEmpty = PrefsMod $ over ParserPrefs \p -> p { prefShowHelpOnEmpty = true }
 
@@ -494,10 +491,10 @@ noBacktrack :: PrefsMod
 noBacktrack = PrefsMod $ over ParserPrefs \p -> p { prefBacktrack = NoBacktrack }
 
 -- | Allow full mixing of subcommand and parent arguments by inlining
--- selected subparsers into the parent parser.
---
--- /NOTE:/ When this option is used, preferences for the subparser which
--- effect the parser behaviour (such as noIntersperse) are ignored.
+-- | selected subparsers into the parent parser.
+-- |
+-- | **Note:** When this option is used, preferences for the subparser which
+-- | effect the parser behaviour (such as noIntersperse) are ignored.
 subparserInline :: PrefsMod
 subparserInline = PrefsMod $ over ParserPrefs \p -> p { prefBacktrack = SubparserInline }
 

--- a/src/Options/Applicative/Common.purs
+++ b/src/Options/Applicative/Common.purs
@@ -3,7 +3,7 @@ module Options.Applicative.Common (
   liftOpt,
   showOption,
 
-  
+
   module Reexport,
 
   -- * Running parsers
@@ -101,7 +101,7 @@ data OptWord = OptWord OptName (Maybe String)
 
 parseWord :: String -> Maybe OptWord
 parseWord = toCharArray >>> List.fromFoldable >>> go
-  where 
+  where
     go ('-' List.: '-' List.: w) = Just $ let
       Tuple opt arg = case List.span (_ /= '=') w of
         { rest: List.Nil} -> (Tuple w Nothing)
@@ -120,7 +120,7 @@ searchParser :: forall m a. Monad m
 searchParser _ (NilP _) = empty
 searchParser f (OptP opt) = f opt
 searchParser f (MultP e) = runExists (\(MultPE p1 p2) ->
-  let 
+  let
     a = searchParser f p1 <#> \p1' -> (p1' <*> p2)
     b = searchParser f p2 <#> \p2' -> (p1 <*> p2')
   in a <!> b
@@ -179,8 +179,8 @@ stepParser pprefs _ arg p = case parseWord arg of
 
 
 -- | Apply a 'Parser' to a command line, and return a result and leftover
--- arguments.  This function returns an error if any parsing error occurs, or
--- if any options are missing and don't have a default value.
+-- | arguments.  This function returns an error if any parsing error occurs, or
+-- | if any options are missing and don't have a default value.
 runParser :: forall m a. MonadP m => ArgPolicy -> IsCmdStart -> Parser a -> Args -> m (Tuple a Args)
 runParser policy isCmdStart p args = case args of
   List.Nil -> exitP isCmdStart policy p result
@@ -215,7 +215,7 @@ runParserFully policy p args = do
     List.Cons head _ -> parseError head (pure unit)
 
 -- | The default value of a 'Parser'.  This function returns an error if any of
--- the options don't have a default value.
+-- | the options don't have a default value.
 evalParser :: forall a. Parser a -> Maybe a
 evalParser (NilP r) = r
 evalParser (OptP _) = Nothing
@@ -226,7 +226,7 @@ evalParser (BindP e) = e # Free.resume' (\p k ->
   ) Just
 
 -- | Map a polymorphic function over all the options of a parser, and collect
--- the results in a list.
+-- | the results in a list.
 mapParser :: forall a b. (forall x. OptHelpInfo -> Option x -> b)
           -> Parser a -> Array b
 mapParser f = flatten <<< treeMapParser f
@@ -258,7 +258,7 @@ treeMapParser g = simplify <<< go false false false g
         let r' = r || hasArg p1 in MultNode [go m d r f p1, go m d r' f p2]
       )
       e
-      
+
     go m d r f (AltP p1 p2) = AltNode [go m d' r f p1, go m d' r f p2]
       where d' = d || has_default p1 || has_default p2
     go _ d r f (BindP e) = e # Free.resume' (\p k ->

--- a/src/Options/Applicative/Extra.purs
+++ b/src/Options/Applicative/Extra.purs
@@ -1,8 +1,7 @@
-{-# LANGUAGE RankNTypes #-}
-module Options.Applicative.Extra
   -- * Extra parser utilities
   --
   -- | This module contains high-level functions to run parsers.
+module Options.Applicative.Extra
   ( helper
   , hsubparser
   , execParser
@@ -68,12 +67,12 @@ exitWith :: forall void. ExitCode -> Effect void
 exitWith c = exit $ fromEnum c
 
 -- | A hidden \"helper\" option which always fails.
---
--- A common usage pattern is to apply this applicatively when
--- creating a 'ParserInfo'
---
--- > opts :: ParserInfo Sample
--- > opts = info (sample <**> helper) mempty
+-- |
+-- | A common usage pattern is to apply this applicatively when
+-- | creating a 'ParserInfo'
+-- |
+-- | > opts :: ParserInfo Sample
+-- | > opts = info (sample <**> helper) mempty
 
 helper :: forall a. Parser (a -> a)
 helper = abortOption ShowHelpText $ fold
@@ -83,8 +82,8 @@ helper = abortOption ShowHelpText $ fold
   , hidden ]
 
 -- | Builder for a command parser with a \"helper\" option attached.
--- Used in the same way as `subparser`, but includes a \"--help|-h\" inside
--- the subcommand.
+-- | Used in the same way as `subparser`, but includes a \"--help|-h\" inside
+-- | the subcommand.
 hsubparser :: forall a. Mod CommandFields a -> Parser a
 hsubparser m = mkParser d g rdr
   where
@@ -95,9 +94,9 @@ hsubparser m = mkParser d g rdr
       { infoParser = pinfo.infoParser <**> helper}
 
 -- | Run a program description.
---
--- Parse command line arguments. Display help text and exit if any parse error
--- occurs.
+-- |
+-- | Parse command line arguments. Display help text and exit if any parse error
+-- | occurs.
 execParser :: forall a. ParserInfo a -> Effect a
 execParser = customExecParser defaultPrefs
 
@@ -126,12 +125,12 @@ handleParseResult (CompletionInvoked compl) = do
       exitSuccess
 
 -- | Extract the actual result from a `ParserResult` value.
---
--- This function returns 'Nothing' in case of errors.  Possible error messages
--- or completion actions are simply discarded.
---
--- If you want to display error messages and invoke completion actions
--- appropriately, use 'handleParseResult' instead.
+-- |
+-- | This function returns 'Nothing' in case of errors.  Possible error messages
+-- | or completion actions are simply discarded.
+-- |
+-- | If you want to display error messages and invoke completion actions
+-- | appropriately, use 'handleParseResult' instead.
 getParseResult :: forall a. ParserResult a -> Maybe a
 getParseResult (Success a) = Just a
 getParseResult _ = Nothing
@@ -153,10 +152,10 @@ execParserPure pprefs pinfo args =
     p = runParserInfo pinfo' $ List.fromFoldable $ args
 
 -- | Generate a `ParserFailure` from a `ParseError` in a given `Context`.
---
--- This function can be used, for example, to show the help text for a parser:
---
--- @handleParseResult <<< Failure $ parserFailure pprefs pinfo ShowHelpText mempty@
+-- |
+-- | This function can be used, for example, to show the help text for a parser:
+-- |
+-- | @handleParseResult <<< Failure $ parserFailure pprefs pinfo ShowHelpText mempty@
 parserFailure :: forall a. ParserPrefs -> ParserInfo a
               -> ParseError -> Array Context
               -> ParserFailure ParserHelp
@@ -185,7 +184,7 @@ parserFailure pprefs pinfo msg ctx = ParserFailure $ \progn ->
     with_context arr i f = case Array.head arr of
       Nothing -> f [] i
       Just (Context _ e) -> runExists (\i' -> f (contextNames arr) i') e
-    
+
     usage_help :: forall x. String -> Array String -> ParserInfo x -> ParserHelp
     usage_help progn names (ParserInfo i) = case msg of
       InfoMsg _

--- a/src/Options/Applicative/Extra.purs
+++ b/src/Options/Applicative/Extra.purs
@@ -155,7 +155,7 @@ execParserPure pprefs pinfo args =
 -- |
 -- | This function can be used, for example, to show the help text for a parser:
 -- |
--- | @handleParseResult <<< Failure $ parserFailure pprefs pinfo ShowHelpText mempty@
+-- | `handleParseResult <<< Failure $ parserFailure pprefs pinfo ShowHelpText mempty`
 parserFailure :: forall a. ParserPrefs -> ParserInfo a
               -> ParseError -> Array Context
               -> ParserFailure ParserHelp

--- a/src/Options/Applicative/Extra.purs
+++ b/src/Options/Applicative/Extra.purs
@@ -66,14 +66,14 @@ exitSuccess = exit $ fromEnum ExitCode.Success
 exitWith :: forall void. ExitCode -> Effect void
 exitWith c = exit $ fromEnum c
 
--- | A hidden \"helper\" option which always fails.
+-- | A hidden "helper" option which always fails. Use this to
+-- | add the `--help` flag to your CLI parser
 -- |
 -- | A common usage pattern is to apply this applicatively when
 -- | creating a 'ParserInfo'
 -- |
 -- | > opts :: ParserInfo Sample
 -- | > opts = info (sample <**> helper) mempty
-
 helper :: forall a. Parser (a -> a)
 helper = abortOption ShowHelpText $ fold
   [ long "help"
@@ -81,8 +81,8 @@ helper = abortOption ShowHelpText $ fold
   , help "Show this help text"
   , hidden ]
 
--- | Builder for a command parser with a \"helper\" option attached.
--- | Used in the same way as `subparser`, but includes a \"--help|-h\" inside
+-- | Builder for a command parser with a "helper" option attached.
+-- | Used in the same way as `subparser`, but includes a `--help|-h` inside
 -- | the subcommand.
 hsubparser :: forall a. Mod CommandFields a -> Parser a
 hsubparser m = mkParser d g rdr

--- a/src/Options/Applicative/Help.purs
+++ b/src/Options/Applicative/Help.purs
@@ -1,7 +1,6 @@
-module Options.Applicative.Help 
-  -- | This is an empty module which re-exports
-  --   the help text system for optparse.
-
+-- | This is an empty module which re-exports
+-- | the help text system for optparse.
+module Options.Applicative.Help
   -- | Pretty printer. Reexports most combinators
   --   from Text.PrettyPrint.ANSI.Leijen
   ( module Options.Applicative.Help.Pretty

--- a/src/Options/Applicative/Types.purs
+++ b/src/Options/Applicative/Types.purs
@@ -375,8 +375,47 @@ manyM p = tailRecM go List.Nil
 someM :: forall a. Parser a -> ParserM (NonEmptyList a)
 someM p = NEL.cons' <$> oneM p <*> manyM p
 
+-- | Parses 0 or more values using the given parser. **Note: this should
+-- | never be used with the `value` modifier.** 
+-- |
+-- | For example, by using this option
+-- | `many (strOption (long "arg-name"))`
+-- |
+-- | one could write
+-- | ```
+-- | command
+-- | # produces Nil
+-- |
+-- | command --arg-name first
+-- | # produces ("first" : Nil)
+-- |
+-- | command --arg-name first --arg-name second
+-- | # produces ("first" : "second" : Nil)
+-- | ```
+-- |
+-- | To parse 1 or more values, see `some` instead.
 many :: forall a. Parser a -> Parser (List a)
 many = manyM >>> fromM
+
+-- | Parses 1 or more values using the given parser. **Note: this should
+-- | never be used with the `value` modifier.**
+-- |
+-- | For example, by using this option
+-- | `some (strOption (long "arg-name"))`
+-- |
+-- | one could write
+-- | ```
+-- | command
+-- | # produces failure message
+-- |
+-- | command --arg-name first
+-- | # produces (NonEmptyList "first" Nil)
+-- |
+-- | command --arg-name first --arg-name second
+-- | # produces (NonEmptyList "first" ("second" : Nil))
+-- | ```
+-- |
+-- | To parse 0 or more values, see `many` instead.
 some :: forall a. Parser a -> Parser (NonEmptyList a)
 some = someM >>> fromM
 

--- a/src/Options/Applicative/Types.purs
+++ b/src/Options/Applicative/Types.purs
@@ -182,7 +182,7 @@ instance optPropertiesShow :: Show OptProperties where
     , propHelp: r.propHelp
     , propMetaVar: r.propMetaVar
     , propShowDefault: r.propShowDefault
-    , propDescMod: map (const "<func>") r.propDescMod 
+    , propDescMod: map (const "<func>") r.propDescMod
     } <> ")"
 
 -- | A single option of a parser.
@@ -194,7 +194,7 @@ derive instance optionNewtype :: Newtype (Option a) _
 data SomeParser = SomeParser (Exists Parser)
 
 -- | Subparser context, containing the 'name' of the subparser, and its parser info.
---   Used by parserFailure to display relevant usage information when parsing inside a subparser fails.
+-- | Used by parserFailure to display relevant usage information when parsing inside a subparser fails.
 data Context = Context String (Exists ParserInfo)
 
 instance optionShow :: Show (Option a) where
@@ -206,7 +206,7 @@ instance optionFunctor :: Functor Option where
 -- | A reader is used by the 'option' and 'argument' builders to parse
 -- | the data passed by the user on the command line into a data type.
 -- |
--- | The most common are 'str' which is used for 'String', there are 
+-- | The most common are 'str' which is used for 'String', there are
 -- | readers for `Int`, `Number`, `Boolean`.
 -- |
 -- | More complex types can use the 'eitherReader' or 'maybeReader'

--- a/src/Text/PrettyPrint/Leijen.purs
+++ b/src/Text/PrettyPrint/Leijen.purs
@@ -1,7 +1,7 @@
--- This is port of https://github.com/ekmett/ansi-wl-pprint to ps without any ansi stuff as it's 
--- used by optparser, later we shuold use [prettyprinter](https://hackage.haskell.org/package/prettyprinter) once
--- [this](https://github.com/pcapriotti/optparse-applicative/issues/273) is fixed.
--- Also see [this](https://github.com/ekmett/ansi-wl-pprint/issues/18)
+-- | This is port of https://github.com/ekmett/ansi-wl-pprint to ps without any ansi stuff as it's
+-- | used by optparser, later we shuold use [prettyprinter](https://hackage.haskell.org/package/prettyprinter) once
+-- | [this](https://github.com/pcapriotti/optparse-applicative/issues/273) is fixed.
+-- | Also see [this](https://github.com/ekmett/ansi-wl-pprint/issues/18)
 module Text.PrettyPrint.Leijen where
 
 import Prelude hiding ((<$>))
@@ -24,49 +24,49 @@ import Partial.Unsafe (unsafeCrashWith)
 -----------------------------------------------------------
 
 -- | The document @(list xs)@ comma separates the documents @xs@ and
--- encloses them in square brackets. The documents are rendered
--- horizontally if that fits the page. Otherwise they are aligned
--- vertically. All comma separators are put in front of the elements.
+-- | encloses them in square brackets. The documents are rendered
+-- | horizontally if that fits the page. Otherwise they are aligned
+-- | vertically. All comma separators are put in front of the elements.
 list :: Array Doc -> Doc
 list            = encloseSep lbracket rbracket comma
 
 -- | The document @(tupled xs)@ comma separates the documents @xs@ and
--- encloses them in parenthesis. The documents are rendered
--- horizontally if that fits the page. Otherwise they are aligned
--- vertically. All comma separators are put in front of the elements.
+-- | encloses them in parenthesis. The documents are rendered
+-- | horizontally if that fits the page. Otherwise they are aligned
+-- | vertically. All comma separators are put in front of the elements.
 tupled :: Array Doc -> Doc
 tupled          = encloseSep lparen   rparen  comma
 
 -- | The document @(semiBraces xs)@ separates the documents @xs@ with
--- semicolons and encloses them in braces. The documents are rendered
--- horizontally if that fits the page. Otherwise they are aligned
--- vertically. All semicolons are put in front of the elements.
+-- | semicolons and encloses them in braces. The documents are rendered
+-- | horizontally if that fits the page. Otherwise they are aligned
+-- | vertically. All semicolons are put in front of the elements.
 semiBraces :: Array Doc -> Doc
 semiBraces      = encloseSep lbrace   rbrace  semi
 
 -- | The document @(encloseSep l r sep xs)@ concatenates the documents
--- @xs@ separated by @sep@ and encloses the resulting document by @l@
--- and @r@. The documents are rendered horizontally if that fits the
--- page. Otherwise they are aligned vertically. All separators are put
--- in front of the elements. For example, the combinator 'list' can be
--- defined with @encloseSep@:
---
--- > list xs = encloseSep lbracket rbracket comma xs
--- > test    = text "list" <+> (list (map int [10,200,3000]))
---
--- Which is layed out with a page width of 20 as:
---
--- @
--- list [10,200,3000]
--- @
---
--- But when the page width is 15, it is layed out as:
---
--- @
--- list [10
---      ,200
---      ,3000]
--- @
+-- | @xs@ separated by @sep@ and encloses the resulting document by @l@
+-- | and @r@. The documents are rendered horizontally if that fits the
+-- | page. Otherwise they are aligned vertically. All separators are put
+-- | in front of the elements. For example, the combinator 'list' can be
+-- | defined with @encloseSep@:
+-- |
+-- | > list xs = encloseSep lbracket rbracket comma xs
+-- | > test    = text "list" <+> (list (map int [10,200,3000]))
+-- |
+-- | Which is layed out with a page width of 20 as:
+-- |
+-- | @
+-- | list [10,200,3000]
+-- | @
+-- |
+-- | But when the page width is 15, it is layed out as:
+-- |
+-- | @
+-- | list [10
+-- |      ,200
+-- |      ,3000]
+-- | @
 encloseSep :: Doc -> Doc -> Doc -> Array Doc -> Doc
 encloseSep left right sep' ds = case ds of
   []  -> left <> right
@@ -78,28 +78,28 @@ encloseSep left right sep' ds = case ds of
 -----------------------------------------------------------
 
 -- | @(punctuate p xs)@ concatenates all documents in @xs@ with
--- document @p@ except for the last document.
---
--- > someText = map text ["words","in","a","tuple"]
--- > test     = parens (align (cat (punctuate comma someText)))
---
--- This is layed out on a page width of 20 as:
---
--- @
--- (words,in,a,tuple)
--- @
---
--- But when the page width is 15, it is layed out as:
---
--- @
--- (words,
---  in,
---  a,
---  tuple)
--- @
---
--- (If you want put the commas in front of their elements instead of
--- at the end, you should use 'tupled' or, in general, 'encloseSep'.)
+-- | document @p@ except for the last document.
+-- |
+-- | > someText = map text ["words","in","a","tuple"]
+-- | > test     = parens (align (cat (punctuate comma someText)))
+-- |
+-- | This is layed out on a page width of 20 as:
+-- |
+-- | @
+-- | (words,in,a,tuple)
+-- | @
+-- |
+-- | But when the page width is 15, it is layed out as:
+-- |
+-- | @
+-- | (words,
+-- |  in,
+-- |  a,
+-- |  tuple)
+-- | @
+-- |
+-- | (If you want put the commas in front of their elements instead of
+-- | at the end, you should use 'tupled' or, in general, 'encloseSep'.)
 punctuate :: Doc -> Array Doc -> Array Doc
 punctuate p arr  = let lastIdx = Array.length arr - 1
   in Array.mapWithIndex (\idx d -> if lastIdx == idx then d else d <> p) arr
@@ -110,10 +110,10 @@ punctuate p arr  = let lastIdx = Array.length arr - 1
 -----------------------------------------------------------
 
 -- | The document @(sep xs)@ concatenates all documents @xs@ either
--- horizontally with @(\<+\>)@, if it fits the page, or vertically with
--- @(\<$\>)@.
---
--- > sep xs  = group (vsep xs)
+-- | horizontally with @(\<+\>)@, if it fits the page, or vertically with
+-- | @(\<$\>)@.
+-- |
+-- | > sep xs  = group (vsep xs)
 sep :: Array Doc -> Doc
 sep             = group <<< vsep
 
@@ -122,160 +122,160 @@ foldr1 f = Array.unsnoc >>> case _ of
   Nothing -> mempty
   Just { init, last } -> foldr f last init
 -- | The document @(fillSep xs)@ concatenates documents @xs@
--- horizontally with @(\<+\>)@ as long as its fits the page, than
--- inserts a @line@ and continues doing that for all documents in
--- @xs@.
---
--- > fillSep xs  = foldr (</>) empty xs
+-- | horizontally with @(\<+\>)@ as long as its fits the page, than
+-- | inserts a @line@ and continues doing that for all documents in
+-- | @xs@.
+-- |
+-- | > fillSep xs  = foldr (</>) empty xs
 fillSep :: Array Doc -> Doc
 fillSep         = foldr1 (</>)
 
 -- | The document @(hsep xs)@ concatenates all documents @xs@
--- horizontally with @(\<+\>)@.
+-- | horizontally with @(\<+\>)@.
 hsep :: Array Doc -> Doc
 hsep            = foldr1 (<+>)
 
 -- | The document @(vsep xs)@ concatenates all documents @xs@
--- vertically with @(\<$\>)@. If a 'group' undoes the line breaks
--- inserted by @vsep@, all documents are separated with a space.
---
--- > someText = map text (words ("text to lay out"))
--- >
--- > test     = text "some" <+> vsep someText
---
--- This is layed out as:
---
--- @
--- some text
--- to
--- lay
--- out
--- @
---
--- The 'align' combinator can be used to align the documents under
--- their first element
---
--- > test     = text "some" <+> align (vsep someText)
---
--- Which is printed as:
---
--- @
--- some text
---      to
---      lay
---      out
--- @
+-- | vertically with @(\<$\>)@. If a 'group' undoes the line breaks
+-- | inserted by @vsep@, all documents are separated with a space.
+-- |
+-- | > someText = map text (words ("text to lay out"))
+-- | >
+-- | > test     = text "some" <+> vsep someText
+-- |
+-- | This is layed out as:
+-- |
+-- | @
+-- | some text
+-- | to
+-- | lay
+-- | out
+-- | @
+-- |
+-- | The 'align' combinator can be used to align the documents under
+-- | their first element
+-- |
+-- | > test     = text "some" <+> align (vsep someText)
+-- |
+-- | Which is printed as:
+-- |
+-- | @
+-- | some text
+-- |      to
+-- |      lay
+-- |      out
+-- | @
 vsep :: Array Doc -> Doc
 vsep = foldr1 (<$>)
 
 -- | The document @(cat xs)@ concatenates all documents @xs@ either
--- horizontally with @(\<\>)@, if it fits the page, or vertically with
--- @(\<$$\>)@.
---
--- > cat xs  = group (vcat xs)
+-- | horizontally with @(\<\>)@, if it fits the page, or vertically with
+-- | @(\<$$\>)@.
+-- |
+-- | > cat xs  = group (vcat xs)
 cat :: Array Doc -> Doc
 cat = group <<< vcat
 
 -- | The document @(fillCat xs)@ concatenates documents @xs@
--- horizontally with @(\<\>)@ as long as its fits the page, than inserts
--- a @linebreak@ and continues doing that for all documents in @xs@.
---
--- > fillCat xs  = foldr1 (<//>) empty
+-- | horizontally with @(\<\>)@ as long as its fits the page, than inserts
+-- | a @linebreak@ and continues doing that for all documents in @xs@.
+-- |
+-- | > fillCat xs  = foldr1 (<//>) empty
 fillCat :: Array Doc -> Doc
 fillCat         = foldr1 (<//>)
 
 -- | The document @(hcat xs)@ concatenates all documents @xs@
--- horizontally with @(\<\>)@.
+-- | horizontally with @(\<\>)@.
 hcat :: Array Doc -> Doc
 hcat            = foldr1 (<>)
 
 -- | The document @(vcat xs)@ concatenates all documents @xs@
--- vertically with @(\<$$\>)@. If a 'group' undoes the line breaks
--- inserted by @vcat@, all documents are directly concatenated.
+-- | vertically with @(\<$$\>)@. If a 'group' undoes the line breaks
+-- | inserted by @vcat@, all documents are directly concatenated.
 vcat :: Array Doc -> Doc
 vcat            = foldr1 (<$$>)
 
 -- | The document @(x \<+\> y)@ concatenates document @x@ and @y@ with a
--- @space@ in between.  (infixr 6)
+-- | @space@ in between.  (infixr 6)
 appendWithSpace :: Doc -> Doc -> Doc
 appendWithSpace x y = x <> space <> y
 infixr 6 appendWithSpace as <+>
 
 -- | The document @(x \<\/\> y)@ concatenates document @x@ and @y@ with a
--- 'softline' in between. This effectively puts @x@ and @y@ either
--- next to each other (with a @space@ in between) or underneath each
--- other. (infixr 5)
+-- | 'softline' in between. This effectively puts @x@ and @y@ either
+-- | next to each other (with a @space@ in between) or underneath each
+-- | other. (infixr 5)
 appendWithSoftline :: Doc -> Doc -> Doc
 appendWithSoftline x y = x <> softline <> y
 infixr 5 appendWithSoftline as </>
 
 -- | The document @(x \<\/\/\> y)@ concatenates document @x@ and @y@ with
--- a 'softbreak' in between. This effectively puts @x@ and @y@ either
--- right next to each other or underneath each other. (infixr 5)
+-- | a 'softbreak' in between. This effectively puts @x@ and @y@ either
+-- | right next to each other or underneath each other. (infixr 5)
 appendWithSoftbreak :: Doc -> Doc -> Doc
 appendWithSoftbreak x y = x <> softbreak <> y
 infixr 5 appendWithSoftbreak as <//>
 
 -- | The document @(x \<$\> y)@ concatenates document @x@ and @y@ with a
--- 'line' in between. (infixr 5)
+-- | 'line' in between. (infixr 5)
 appendWithLine :: Doc -> Doc -> Doc
 appendWithLine x y = x <> line <> y
 infixr 5 appendWithLine as <$>
 
 -- | The document @(x \<$$\> y)@ concatenates document @x@ and @y@ with
--- a @linebreak@ in between. (infixr 5)
+-- | a @linebreak@ in between. (infixr 5)
 appendWithLinebreak :: Doc -> Doc -> Doc
 appendWithLinebreak x y = x <> linebreak <> y
 infixr 5 appendWithLinebreak as <$$>
 
 -- | The document @softline@ behaves like 'space' if the resulting
--- output fits the page, otherwise it behaves like 'line'.
---
--- > softline = group line
+-- | output fits the page, otherwise it behaves like 'line'.
+-- |
+-- | > softline = group line
 softline :: Doc
 softline        = group line
 
 -- | The document @softbreak@ behaves like 'empty' if the resulting
--- output fits the page, otherwise it behaves like 'line'.
---
--- > softbreak  = group linebreak
+-- | output fits the page, otherwise it behaves like 'line'.
+-- |
+-- | > softbreak  = group linebreak
 softbreak :: Doc
 softbreak       = group linebreak
 
 -- | Document @(squotes x)@ encloses document @x@ with single quotes
--- \"'\".
+-- | \"'\".
 squotes :: Doc -> Doc
 squotes         = enclose squote squote
 
 -- | Document @(dquotes x)@ encloses document @x@ with double quotes
--- '\"'.
+-- | '\"'.
 dquotes :: Doc -> Doc
 dquotes         = enclose dquote dquote
 
 -- | Document @(braces x)@ encloses document @x@ in braces, \"{\" and
--- \"}\".
+-- | \"}\".
 braces :: Doc -> Doc
 braces          = enclose lbrace rbrace
 
 -- | Document @(parens x)@ encloses document @x@ in parenthesis, \"(\"
--- and \")\".
+-- | and \")\".
 parens :: Doc -> Doc
 parens          = enclose lparen rparen
 
 -- | Document @(angles x)@ encloses document @x@ in angles, \"\<\" and
--- \"\>\".
+-- | \"\>\".
 angles :: Doc -> Doc
 angles          = enclose langle rangle
 
 -- | Document @(brackets x)@ encloses document @x@ in square brackets,
--- \"[\" and \"]\".
+-- | \"[\" and \"]\".
 brackets :: Doc -> Doc
 brackets        = enclose lbracket rbracket
 
 -- | The document @(enclose l r x)@ encloses document @x@ between
--- documents @l@ and @r@ using @(\<\>)@.
---
--- > enclose l r x   = l <> x <> r
+-- | documents @l@ and @r@ using @(\<\>)@.
+-- |
+-- | > enclose l r x   = l <> x <> r
 enclose :: Doc -> Doc -> Doc -> Doc
 enclose l r x   = l <> x <> r
 
@@ -320,8 +320,8 @@ colon           = Char ':'
 comma :: Doc
 comma           = Char ','
 -- | The document @space@ contains a single space, \" \".
---
--- > x <+> y   = x <> space <> y
+-- |
+-- | > x <+> y   = x <> space <> y
 space :: Doc
 space           = Char ' '
 -- | The document @dot@ contains a single dot, \".\".
@@ -341,9 +341,9 @@ equals          = Char '='
 -- string is like "text" but replaces '\n' by "line"
 
 -- | The document @(string s)@ concatenates all characters in @s@
--- using @line@ for newline characters and @char@ for all other
--- characters. It is used instead of 'text' whenever the text contains
--- newline characters.
+-- | using @line@ for newline characters and @char@ for all other
+-- | characters. It is used instead of 'text' whenever the text contains
+-- | newline characters.
 string :: String -> Doc
 string = intercalate line <<< map text <<< split (String.Pattern "\n")
 
@@ -418,50 +418,50 @@ number f         = text (show f)
 -----------------------------------------------------------
 
 -- | The document @(fillBreak i x)@ first renders document @x@. It
--- than appends @space@s until the width is equal to @i@. If the
--- width of @x@ is already larger than @i@, the nesting level is
--- increased by @i@ and a @line@ is appended. When we redefine @ptype@
--- in the previous example to use @fillBreak@, we get a useful
--- variation of the previous output:
---
--- > ptype (name,tp)
--- >        = fillBreak 6 (text name) <+> text "::" <+> text tp
---
--- The output will now be:
---
--- @
--- let empty  :: Doc
---     nest   :: Int -> Doc -> Doc
---     linebreak
---            :: Doc
--- @
+-- | than appends @space@s until the width is equal to @i@. If the
+-- | width of @x@ is already larger than @i@, the nesting level is
+-- | increased by @i@ and a @line@ is appended. When we redefine @ptype@
+-- | in the previous example to use @fillBreak@, we get a useful
+-- | variation of the previous output:
+-- |
+-- | > ptype (name,tp)
+-- | >        = fillBreak 6 (text name) <+> text "::" <+> text tp
+-- |
+-- | The output will now be:
+-- |
+-- | @
+-- | let empty  :: Doc
+-- |     nest   :: Int -> Doc -> Doc
+-- |     linebreak
+-- |            :: Doc
+-- | @
 fillBreak :: Int -> Doc -> Doc
 fillBreak f x   = width x (\w ->
                   if (w > f) then nest f linebreak
                              else text (spaces (f - w)))
 
 -- | The document @(fill i x)@ renders document @x@. It than appends
--- @space@s until the width is equal to @i@. If the width of @x@ is
--- already larger, nothing is appended. This combinator is quite
--- useful in practice to output a list of bindings. The following
--- example demonstrates this.
---
--- > types  = [("empty","Doc")
--- >          ,("nest","Int -> Doc -> Doc")
--- >          ,("linebreak","Doc")]
--- >
--- > ptype (name,tp)
--- >        = fill 6 (text name) <+> text "::" <+> text tp
--- >
--- > test   = text "let" <+> align (vcat (map ptype types))
---
--- Which is layed out as:
---
--- @
--- let empty  :: Doc
---     nest   :: Int -> Doc -> Doc
---     linebreak :: Doc
--- @
+-- | @space@s until the width is equal to @i@. If the width of @x@ is
+-- | already larger, nothing is appended. This combinator is quite
+-- | useful in practice to output a list of bindings. The following
+-- | example demonstrates this.
+-- |
+-- | > types  = [("empty","Doc")
+-- | >          ,("nest","Int -> Doc -> Doc")
+-- | >          ,("linebreak","Doc")]
+-- | >
+-- | > ptype (name,tp)
+-- | >        = fill 6 (text name) <+> text "::" <+> text tp
+-- | >
+-- | > test   = text "let" <+> align (vcat (map ptype types))
+-- |
+-- | Which is layed out as:
+-- |
+-- | @
+-- | let empty  :: Doc
+-- |     nest   :: Int -> Doc -> Doc
+-- |     linebreak :: Doc
+-- | @
 fill :: Int -> Doc -> Doc
 fill f d        = width d (\w ->
                   if (w >= f) then empty
@@ -475,60 +475,60 @@ width d f       = column (\k1 -> d <> column (\k2 -> f (k2 - k1)))
 -----------------------------------------------------------
 
 -- | The document @(indent i x)@ indents document @x@ with @i@ spaces.
---
--- > test  = indent 4 (fillSep (map text
--- >         (words "the indent combinator indents these words !")))
---
--- Which lays out with a page width of 20 as:
---
--- @
---     the indent
---     combinator
---     indents these
---     words !
--- @
+-- |
+-- | > test  = indent 4 (fillSep (map text
+-- | >         (words "the indent combinator indents these words !")))
+-- |
+-- | Which lays out with a page width of 20 as:
+-- |
+-- | @
+-- |     the indent
+-- |     combinator
+-- |     indents these
+-- |     words !
+-- | @
 indent :: Int -> Doc -> Doc
 indent i d      = hang i (text (spaces i) <> d)
 
 -- | The hang combinator implements hanging indentation. The document
--- @(hang i x)@ renders document @x@ with a nesting level set to the
--- current column plus @i@. The following example uses hanging
--- indentation for some text:
---
--- > test  = hang 4 (fillSep (map text
--- >         (words "the hang combinator indents these words !")))
---
--- Which lays out on a page with a width of 20 characters as:
---
--- @
--- the hang combinator
---     indents these
---     words !
--- @
---
--- The @hang@ combinator is implemented as:
---
--- > hang i x  = align (nest i x)
+-- | @(hang i x)@ renders document @x@ with a nesting level set to the
+-- | current column plus @i@. The following example uses hanging
+-- | indentation for some text:
+-- |
+-- | > test  = hang 4 (fillSep (map text
+-- | >         (words "the hang combinator indents these words !")))
+-- |
+-- | Which lays out on a page with a width of 20 characters as:
+-- |
+-- | @
+-- | the hang combinator
+-- |     indents these
+-- |     words !
+-- | @
+-- |
+-- | The @hang@ combinator is implemented as:
+-- |
+-- | > hang i x  = align (nest i x)
 hang :: Int -> Doc -> Doc
 hang i d        = align (nest i d)
 
 -- | The document @(align x)@ renders document @x@ with the nesting
--- level set to the current column. It is used for example to
--- implement 'hang'.
---
--- As an example, we will put a document right above another one,
--- regardless of the current nesting level:
---
--- > x $$ y  = align (x <$> y)
---
--- > test    = text "hi" <+> (text "nice" $$ text "world")
---
--- which will be layed out as:
---
--- @
--- hi nice
---    world
--- @
+-- | level set to the current column. It is used for example to
+-- | implement 'hang'.
+-- |
+-- | As an example, we will put a document right above another one,
+-- | regardless of the current nesting level:
+-- |
+-- | > x $$ y  = align (x <$> y)
+-- |
+-- | > test    = text "hi" <+> (text "nice" $$ text "world")
+-- |
+-- | which will be layed out as:
+-- |
+-- | @
+-- | hi nice
+-- |    world
+-- | @
 align :: Doc -> Doc
 align d         = column (\k ->
                   nesting (\i -> nest (k - i) d))   --nesting might be negative :-)
@@ -540,23 +540,23 @@ align d         = column (\k ->
 -----------------------------------------------------------
 
 -- | The abstract data type @Doc@ represents pretty documents.
---
--- More specifically, a value of type @Doc@ represents a non-empty set of
--- possible renderings of a document.  The rendering functions select one of
--- these possibilities.
---
--- @Doc@ is an instance of the 'Show' class. @(show doc)@ pretty
--- prints document @doc@ with a page width of 80 characters and a
--- ribbon width of 32 characters.
---
--- > show (text "hello" <$> text "world")
---
--- Which would return the string \"hello\\nworld\", i.e.
---
--- @
--- hello
--- world
--- @
+-- |
+-- | More specifically, a value of type @Doc@ represents a non-empty set of
+-- | possible renderings of a document.  The rendering functions select one of
+-- | these possibilities.
+-- |
+-- | @Doc@ is an instance of the 'Show' class. @(show doc)@ pretty
+-- | prints document @doc@ with a page width of 80 characters and a
+-- | ribbon width of 32 characters.
+-- |
+-- | > show (text "hello" <$> text "world")
+-- |
+-- | Which would return the string \"hello\\nworld\", i.e.
+-- |
+-- | @
+-- | hello
+-- | world
+-- | @
 data Doc        = Fail
                 | Empty
                 | Char Char             -- invariant: char is not '\n'
@@ -572,17 +572,17 @@ data Doc        = Fail
                 | Nesting (Int -> Doc)
 
 -- | The data type @SimpleDoc@ represents rendered documents and is
--- used by the display functions.
---
--- Whereas values of the data type 'Doc' represent non-empty sets of possible
--- renderings of a document, values of the data type @SimpleDoc@ represent
--- single renderings of a document.
---
--- The @Int@ in @SText@ contains the length of the string. The @Int@
--- in @SLine@ contains the indentation for that line. The library
--- provides two default display functions 'displayS' and
--- 'displayIO'. You can provide your own display function by writing a
--- function from a @SimpleDoc@ to your own output format.
+-- | used by the display functions.
+-- |
+-- | Whereas values of the data type 'Doc' represent non-empty sets of possible
+-- | renderings of a document, values of the data type @SimpleDoc@ represent
+-- | single renderings of a document.
+-- |
+-- | The @Int@ in @SText@ contains the length of the string. The @Int@
+-- | in @SLine@ contains the indentation for that line. The library
+-- | provides two default display functions 'displayS' and
+-- | 'displayIO'. You can provide your own display function by writing a
+-- | function from a @SimpleDoc@ to your own output format.
 data SimpleDoc  = SFail
                 | SEmpty
                 | SChar Char SimpleDoc
@@ -600,40 +600,40 @@ instance docMonoid :: Monoid Doc where
   mempty = empty
 
 -- | The empty document is, indeed, empty. Although @empty@ has no
--- content, it does have a \'height\' of 1 and behaves exactly like
--- @(text \"\")@ (and is therefore not a unit of @\<$\>@).
+-- | content, it does have a \'height\' of 1 and behaves exactly like
+-- | @(text \"\")@ (and is therefore not a unit of @\<$\>@).
 empty :: Doc
 empty           = Empty
 
 -- | The document @(char c)@ contains the literal character @c@. The
--- character shouldn't be a newline (@'\n'@), the function 'line'
--- should be used for line breaks.
+-- | character shouldn't be a newline (@'\n'@), the function 'line'
+-- | should be used for line breaks.
 char :: Char -> Doc
 char '\n'       = line
 char c          = Char c
 
 -- | The document @(text s)@ contains the literal string @s@. The
--- string shouldn't contain any newline (@'\n'@) characters. If the
--- string contains newline characters, the function 'string' should be
--- used.
+-- | string shouldn't contain any newline (@'\n'@) characters. If the
+-- | string contains newline characters, the function 'string' should be
+-- | used.
 text :: String -> Doc
 text ""         = Empty
 text s          = Text (String.length s) s
 
 -- | The @line@ document advances to the next line and indents to the
--- current nesting level. Document @line@ behaves like @(text \" \")@
--- if the line break is undone by 'group'.
+-- | current nesting level. Document @line@ behaves like @(text \" \")@
+-- | if the line break is undone by 'group'.
 line :: Doc
 line            = FlatAlt Line space
 
 -- | The @linebreak@ document advances to the next line and indents to
--- the current nesting level. Document @linebreak@ behaves like
--- 'empty' if the line break is undone by 'group'.
+-- | the current nesting level. Document @linebreak@ behaves like
+-- | 'empty' if the line break is undone by 'group'.
 linebreak :: Doc
 linebreak       = FlatAlt Line empty
 
 -- | A linebreak that will never be flattened; it is guaranteed to render
--- as a newline.
+-- | as a newline.
 hardline :: Doc
 hardline = Line
 
@@ -641,18 +641,18 @@ beside :: Doc -> Doc -> Doc
 beside x y      = Cat x y
 
 -- | The document @(nest i x)@ renders document @x@ with the current
--- indentation level increased by i (See also 'hang', 'align' and
--- 'indent').
---
--- > nest 2 (text "hello" <$> text "world") <$> text "!"
---
--- outputs as:
---
--- @
--- hello
---   world
--- !
--- @
+-- | indentation level increased by i (See also 'hang', 'align' and
+-- | 'indent').
+-- |
+-- | > nest 2 (text "hello" <$> text "world") <$> text "!"
+-- |
+-- | outputs as:
+-- |
+-- | @
+-- | hello
+-- |   world
+-- | !
+-- | @
 nest :: Int -> Doc -> Doc
 nest i x        = Nest i x
 
@@ -666,15 +666,15 @@ columns :: (Maybe Int -> Doc) -> Doc
 columns f       = Columns f
 
 -- | The @group@ combinator is used to specify alternative
--- layouts. The document @(group x)@ undoes all line breaks in
--- document @x@. The resulting line is added to the current line if
--- that fits the page. Otherwise, the document @x@ is rendered without
--- any changes.
+-- | layouts. The document @(group x)@ undoes all line breaks in
+-- | document @x@. The resulting line is added to the current line if
+-- | that fits the page. Otherwise, the document @x@ is rendered without
+-- | any changes.
 group :: Doc -> Doc
 group x         = Union (flatten x) x
 
 -- | A document that is normally rendered as the first argument, but
--- when flattened, is rendered as the second document.
+-- | when flattened, is rendered as the second document.
 flatAlt :: Doc -> Doc -> Doc
 flatAlt = FlatAlt
 
@@ -698,53 +698,53 @@ flatten other            = other                     --Empty,Char,Text
 -- renderPretty: the default pretty printing algorithm
 -----------------------------------------------------------
 
--- list of indentation/document pairs; saves an indirection over [(Int,Doc)]
+-- | list of indentation/document pairs; saves an indirection over [(Int,Doc)]
 data Docs   = Nil
             | Cons Int Doc Docs
 
 -- | This is the default pretty printer which is used by 'show',
--- 'putDoc' and 'hPutDoc'. @(renderPretty ribbonfrac width x)@ renders
--- document @x@ with a page width of @width@ and a ribbon width of
--- @(ribbonfrac * width)@ characters. The ribbon width is the maximal
--- amount of non-indentation characters on a line. The parameter
--- @ribbonfrac@ should be between @0.0@ and @1.0@. If it is lower or
--- higher, the ribbon width will be 0 or @width@ respectively.
+-- | 'putDoc' and 'hPutDoc'. @(renderPretty ribbonfrac width x)@ renders
+-- | document @x@ with a page width of @width@ and a ribbon width of
+-- | @(ribbonfrac * width)@ characters. The ribbon width is the maximal
+-- | amount of non-indentation characters on a line. The parameter
+-- | @ribbonfrac@ should be between @0.0@ and @1.0@. If it is lower or
+-- | higher, the ribbon width will be 0 or @width@ respectively.
 renderPretty :: Number -> Int -> Doc -> SimpleDoc
 renderPretty = renderFits fits1
 
 -- | A slightly smarter rendering algorithm with more lookahead. It provides
--- provide earlier breaking on deeply nested structures
--- For example, consider this python-ish pseudocode:
--- @fun(fun(fun(fun(fun([abcdefg, abcdefg])))))@
--- If we put a softbreak (+ nesting 2) after each open parenthesis, and align
--- the elements of the list to match the opening brackets, this will render with
--- @renderPretty@ and a page width of 20 as:
--- @
--- fun(fun(fun(fun(fun([
---                     | abcdef,
---                     | abcdef,
---                     ]
---   )))))             |
--- @
--- Where the 20c. boundary has been marked with |.
--- Because @renderPretty@ only uses one-line lookahead, it sees that the first
--- line fits, and is stuck putting the second and third lines after the 20-c
--- mark. In contrast, @renderSmart@ will continue to check that the potential
--- document up to the end of the indentation level. Thus, it will format the
--- document as:
---
--- @
--- fun(                |
---   fun(              |
---     fun(            |
---       fun(          |
---         fun([       |
---               abcdef,
---               abcdef,
---             ]       |
---   )))))             |
--- @
--- Which fits within the 20c. boundary.
+-- | provide earlier breaking on deeply nested structures
+-- | For example, consider this python-ish pseudocode:
+-- | @fun(fun(fun(fun(fun([abcdefg, abcdefg])))))@
+-- | If we put a softbreak (+ nesting 2) after each open parenthesis, and align
+-- | the elements of the list to match the opening brackets, this will render with
+-- | @renderPretty@ and a page width of 20 as:
+-- | @
+-- | fun(fun(fun(fun(fun([
+-- |                     | abcdef,
+-- |                     | abcdef,
+-- |                     ]
+-- |   )))))             |
+-- | @
+-- | Where the 20c. boundary has been marked with |.
+-- | Because @renderPretty@ only uses one-line lookahead, it sees that the first
+-- | line fits, and is stuck putting the second and third lines after the 20-c
+-- | mark. In contrast, @renderSmart@ will continue to check that the potential
+-- | document up to the end of the indentation level. Thus, it will format the
+-- | document as:
+-- |
+-- | @
+-- | fun(                |
+-- |   fun(              |
+-- |     fun(            |
+-- |       fun(          |
+-- |         fun([       |
+-- |               abcdef,
+-- |               abcdef,
+-- |             ]       |
+-- |   )))))             |
+-- | @
+-- | Which fits within the 20c. boundary.
 renderSmart :: Number -> Int -> Doc -> SimpleDoc
 renderSmart = renderFits fitsR
 
@@ -793,13 +793,13 @@ renderFits fits rfrac w headNode
       -- nicest n k x y =
       --   let width' = min (w - k) (r - k + n)
       --   in if fits w (min n k) width' x then x else y
-      nicest' n k i ds x y = 
+      nicest' n k i ds x y =
         let
           x' = (best n k (Cons i x ds))
           width' = min (w - k) (r - k + n)
         in if fits w (min n k) width' x' then x' else let y' = best n k (Cons i y ds) in y'
-      
--- @fits1@ does 1 line lookahead.
+
+-- | @fits1@ does 1 line lookahead.
 fits1 :: Int -> Int -> Int -> SimpleDoc -> Boolean
 fits1 _ _ w x        | w < 0         = false
 fits1 _ _ w SFail                    = false
@@ -808,16 +808,16 @@ fits1 p m w (SChar c x)              = fits1 p m (w - 1) x
 fits1 p m w (SText l s x)            = fits1 p m (w - l) x
 fits1 _ _ w (SLine i x)              = true
 
--- @fitsR@ has a little more lookahead: assuming that nesting roughly
--- corresponds to syntactic depth, @fitsR@ checks that not only the current line
--- fits, but the entire syntactic structure being formatted at this level of
--- indentation fits. If we were to remove the second case for @SLine@, we would
--- check that not only the current structure fits, but also the rest of the
--- document, which would be slightly more intelligent but would have exponential
--- runtime (and is prohibitively expensive in practice).
--- p = pagewidth
--- m = minimum nesting level to fit in
--- w = the width in which to fit the first line
+-- | @fitsR@ has a little more lookahead: assuming that nesting roughly
+-- | corresponds to syntactic depth, @fitsR@ checks that not only the current line
+-- | fits, but the entire syntactic structure being formatted at this level of
+-- | indentation fits. If we were to remove the second case for @SLine@, we would
+-- | check that not only the current structure fits, but also the rest of the
+-- | document, which would be slightly more intelligent but would have exponential
+-- | runtime (and is prohibitively expensive in practice).
+-- | p = pagewidth
+-- | m = minimum nesting level to fit in
+-- | w = the width in which to fit the first line
 fitsR :: Int -> Int -> Int -> SimpleDoc -> Boolean
 fitsR p m w x        | w < 0         = false
 fitsR p m w SFail                    = false
@@ -833,12 +833,12 @@ fitsR p m w (SLine i x) | m < i      = fitsR p m (p - i) x
 -----------------------------------------------------------
 
 -- | @(renderCompact x)@ renders document @x@ without adding any
--- indentation. Since no \'pretty\' printing is involved, this
--- renderer is very fast. The resulting output contains fewer
--- characters than a pretty printed version and can be used for output
--- that is read by other programs.
---
--- This rendering function does not add any colorisation information.
+-- | indentation. Since no \'pretty\' printing is involved, this
+-- | renderer is very fast. The resulting output contains fewer
+-- | characters than a pretty printed version and can be used for output
+-- | that is read by other programs.
+-- |
+-- | This rendering function does not add any colorisation information.
 renderCompact :: Doc -> SimpleDoc
 renderCompact
     = scan 0 <<< List.singleton
@@ -865,15 +865,15 @@ renderCompact
 -----------------------------------------------------------
 
 -- | @(displayS simpleDoc)@ takes the output @simpleDoc@ from a
--- rendering function and transforms it to a 'ShowS' type (for use in
--- the 'Show' class).
---
--- > showWidth :: Int -> Doc -> String
--- > showWidth w x   = displayS (renderPretty 0.4 w x) ""
---
--- ANSI color information will be discarded by this function unless
--- you are running on a Unix-like operating system. This is due to
--- a technical limitation in Windows ANSI support.
+-- | rendering function and transforms it to a 'ShowS' type (for use in
+-- | the 'Show' class).
+-- |
+-- | > showWidth :: Int -> Doc -> String
+-- | > showWidth w x   = displayS (renderPretty 0.4 w x) ""
+-- |
+-- | ANSI color information will be discarded by this function unless
+-- | you are running on a Unix-like operating system. This is due to
+-- | a technical limitation in Windows ANSI support.
 displayS :: SimpleDoc -> String
 displayS SFail              = unsafeCrashWith $ "@SFail@ can not appear uncaught in a rendered @SimpleDoc@"
 displayS SEmpty             = ""


### PR DESCRIPTION
This currently addresses parts of #3 

- Builder module was looked through carefully
- Other modules just expose all of their docs. Other things like "`@word@`" 
were not converted to "`word`" or things like that

I'm also not entirely sure how to directly translate Haskell docs to PS docs