### PR TITLE
Fix multiString ReadM example

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,7 +618,7 @@ Right way (and consistent: use `eitherReader` to define our own `ReadM` that pro
 ```purescript
 multiString :: Pattern -> ReadM (Array String)
 multiString splitPattern = eitherReader \s ->
-  let strArray = filter String.null $ split splitPattern s
+  let strArray = filter (not <<< String.null) $ split splitPattern s
   in
     if Array.null strArray
       then Left "got empty string as input"


### PR DESCRIPTION
Pretty sad, but I didn't actually need to use a different multi-string parser until working on my `learn-halogen` project, where I realized that my example doesn't actually work. 

This PR fixes that example: only keep non-empty strings