### PR TITLE
Topic/remove plus

### DIFF
--- a/src/Options/Applicative/BashCompletion.purs
+++ b/src/Options/Applicative/BashCompletion.purs
@@ -13,7 +13,7 @@ import Data.Array as Array
 import Data.Array.NonEmpty as NEA
 import Data.Either (Either(..))
 import Data.Exists (runExists)
-import Data.Foldable (fold, oneOf)
+import Data.Foldable (fold)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Data.List as List
@@ -52,8 +52,8 @@ bashCompletionParser pinfo pprefs = complParser
     failure opts = CompletionResult
       { execCompletion: \progn -> unLines <$> opts progn }
 
-    complParser = oneOf
-      [ failure <$>
+    complParser =
+      ( failure <$>
         (  bashCompletionQuery pinfo pprefs
         -- To get rich completions, one just needs the first
         -- command. To customise the lengths, use either of
@@ -68,16 +68,16 @@ bashCompletionParser pinfo pprefs = complParser
         <*> (map Array.fromFoldable <<< many <<< strOption) (long "bash-completion-word"
                                   `append` internal)
         <*> option int (long "bash-completion-index" `append` internal) )
-      , failure <$>
+      ) <|> failure <$>
           (bashCompletionScript <$>
             strOption (long "bash-completion-script" `append` internal))
-      , failure <$>
+        <|> failure <$>
           (fishCompletionScript <$>
             strOption (long "fish-completion-script" `append` internal))
-      , failure <$>
+        <|> failure <$>
           (zshCompletionScript <$>
             strOption (long "zsh-completion-script" `append` internal))
-      ]
+
 
 bashCompletionQuery :: forall a. ParserInfo a -> ParserPrefs -> Richness -> Array String -> Int -> String -> Effect (Array String)
 bashCompletionQuery pinfo pprefs richness ws i _ = case runCompletion compl pprefs of

--- a/src/Options/Applicative/Builder/Internal.purs
+++ b/src/Options/Applicative/Builder/Internal.purs
@@ -169,9 +169,11 @@ mkParser :: forall a. DefaultProp a
          -> (OptProperties -> OptProperties)
          -> OptReader a
          -> Parser a
-mkParser d@(DefaultProp def _) g rdr = liftOpt opt `alt` maybe empty pure def
-  where
-    opt = mkOption d g rdr
+mkParser d@(DefaultProp def _) g rdr =
+  let
+    o = liftOpt $ mkOption d g rdr
+  in
+    maybe o (\a -> o `alt` pure a) def
 
 mkOption :: forall a. DefaultProp a
          -> (OptProperties -> OptProperties)

--- a/src/Options/Applicative/Builder/Internal.purs
+++ b/src/Options/Applicative/Builder/Internal.purs
@@ -27,7 +27,6 @@ import Prelude
 import Options.Applicative.Common (liftOpt)
 import Options.Applicative.Types (Completer, OptName, OptProperties(..), OptReader, OptVisibility(..), Option(..), ParseError, Parser, ParserInfo)
 import Control.Alt (alt)
-import Control.Plus (empty)
 import Data.Maybe (Maybe(..), maybe)
 import Data.Newtype (class Newtype, over)
 import Data.Tuple (Tuple, fst, lookup)

--- a/src/Options/Applicative/Extra.purs
+++ b/src/Options/Applicative/Extra.purs
@@ -170,7 +170,6 @@ parserFailure pprefs pinfo msg ctx = ParserFailure $ \progn ->
   where
     exit_code = case msg of
       ErrorMsg _        -> (un ParserInfo pinfo).infoFailureCode
-      UnknownError       -> (un ParserInfo pinfo).infoFailureCode
       MissingError _ _    -> (un ParserInfo pinfo).infoFailureCode
       ExpectsArgError _ -> (un ParserInfo pinfo).infoFailureCode
       UnexpectedError _ _ -> (un ParserInfo pinfo).infoFailureCode
@@ -224,10 +223,6 @@ parserFailure pprefs pinfo msg ctx = ParserFailure $ \progn ->
               then "Invalid option `" <> arg <> "'"
               else "Invalid argument `" <> arg <> "'"
           in stringChunk msg'
-
-      UnknownError
-        -> mempty
-
 
     suggestion_help = suggestionsHelp $ case msg of
       UnexpectedError arg (SomeParser x)

--- a/src/Options/Applicative/Types.purs
+++ b/src/Options/Applicative/Types.purs
@@ -38,12 +38,13 @@ module Options.Applicative.Types (
   optShowDefault,
   optDescMod,
   many,
-  some
+  some,
+  optional
   ) where
 
 import Prelude
 
-import Control.Alternative (class Alt, class Alternative, class Plus, alt, (<|>))
+import Control.Alternative (class Alt, alt, (<|>))
 import Control.Monad.Except (Except)
 import Control.Monad.Except.Trans (class MonadThrow, throwError)
 import Control.Monad.Free (Free, liftF)
@@ -398,6 +399,9 @@ many = manyM >>> fromM
 -- | To parse 0 or more values, see `many` instead.
 some :: forall a. Parser a -> Parser (NonEmptyList a)
 some = someM >>> fromM
+
+optional :: forall f a. Alt f => Applicative f => f a -> f (Maybe a)
+optional a = map Just a <|> pure Nothing
 
 -- | optparse-applicative supplies a rich completion system for bash,
 -- | zsh, and fish shells.

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -7,7 +7,6 @@ import Control.Lazy (defer)
 import Control.Monad.Gen (class MonadGen, chooseFloat, chooseInt, suchThat)
 import Control.Monad.Gen.Common (genMaybe)
 import Control.Monad.Rec.Class (class MonadRec)
-import Control.MonadZero (guard)
 import Data.Array (fold, foldl, replicate)
 import Data.Array as Array
 import Data.Char.Gen (genUnicodeChar)
@@ -15,7 +14,7 @@ import Data.Either (Either(..))
 import Data.Foldable (elem)
 import Data.Int (even, odd)
 import Data.List as List
-import Data.Maybe (Maybe(..), fromMaybe, isJust, optional)
+import Data.Maybe (Maybe(..), fromMaybe, isJust)
 import Data.String (Pattern)
 import Data.String as String
 import Data.String.CodeUnits (toCharArray)
@@ -35,7 +34,7 @@ import ExitCodes as ExitCode
 import Options.Applicative (argument, briefDesc, columns, command, completeWith, defaultPrefs, disambiguate, execParserPure, flag', forwardOptions, header, help, (<**>), helper, hidden, info, int, long, metavar, noBacktrack, noIntersperse, option, prefs, progDesc, renderFailure, short, showDefault, showHelpOnEmpty, showHelpOnError, str, strArgument, strOption, subparser, subparserInline, switch, value)
 import Options.Applicative.Help (Chunk(..), editDistance, extractChunk, isEmpty, listToChunk, paragraph, stringChunk)
 import Options.Applicative.Internal.Utils (lines, words)
-import Options.Applicative.Types (CompletionResult(..), ParserFailure, ParserHelp, ParserInfo, ParserPrefs, ParserResult(..), ReadM, many, readerAsk, readerError, some)
+import Options.Applicative.Types (CompletionResult(..), ParserFailure, ParserHelp, ParserInfo, ParserPrefs, ParserResult(..), ReadM, many, readerAsk, readerError, some, optional)
 import Test.QuickCheck ((<?>), (===))
 import Test.QuickCheck as QC
 import Test.QuickCheck.Gen (Gen)
@@ -85,7 +84,7 @@ assertCompletion x f = case x of
     pure $ f completions
   Failure _   -> pure $ counterExample "unexpected failure"
   Success val -> pure $ counterExample ("unexpected result " <> show val)
-  
+
 assertHasLine :: String -> String -> QC.Result
 assertHasLine l s = l `elem` lines s <?> ("expected line:\n\t" <> l <> "\nnot found")
 
@@ -95,8 +94,10 @@ isInfixOf p = String.indexOf p >>> isJust
 condr :: (Int -> Boolean) -> ReadM Int
 condr f = do
   x <- int
-  guard (f x)
-  pure x
+  if (f x) then
+    pure x
+  else
+    readerError "oh no"
 
 type Asset = { name :: String, msg :: String }
 


### PR DESCRIPTION
Nice port.

Purescript's class hierarchy is more granular than Haskell's; and has in its prelude an `Alt` preceding `Alternative`.

In the Haskell version, a parser is essentially a free `Alternative`, with `NilP None` being empty, and `NilP . Just` being pure. But we don't actually need the empty at all though; and really its existence just means there are places where we can't give meaningful error messages.

Similarly, the empty on `ReadM` just gives no error message, which is pretty awful.

I'm not sure how much you plan on deviating from our version; nor whether you are up for breaking changes. I mostly did this to know I may be able to in the future in the Haskell version.

So feel free to not merge this (and I would probably suggest against it until https://github.com/purescript/purescript-maybe/issues/45 is addressed).

